### PR TITLE
support prop: Option<T> as well as prop?: T

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^2.3.2"
   },
   "dependencies": {
+    "deep-freeze-strict": "^1.1.1",
     "lodash": "^4.17.4",
     "read-pkg-up": "^2.0.0",
     "rosie": "^1.6.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -196,7 +196,7 @@ const runTypeGenerator = () => {
   const relativePathToInput = relativeImportPath(utilsPath, inputPath);
   const relativePathToTypes = relativeImportPath(utilsPath, typesPath);
 
-  coerceOutput.unshift(baseTemplate(relativePathToInput, relativePathToTypes));
+  coerceOutput.unshift(baseTemplate(useOptionTypes, relativePathToInput, relativePathToTypes));
 
   fs.writeFileSync(typesPath, `${schemaOutput.join("\n\n")}\n`);
   fs.writeFileSync(utilsPath, `${coerceOutput.join("\n\n")}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import fs = require("fs");
 import * as joi from "joi";
-import { find, get, has, isObject, map, mapKeys, pick, pickBy, reduce, some } from "lodash";
+import { find, get, has, identity, isObject, map, mapKeys, pick, pickBy, reduce, some } from "lodash";
 import * as path from "path";
 import { Factory } from "rosie";
 
@@ -38,6 +38,7 @@ const projectPath = path.dirname(packageJson.path);
 const inputPath = path.join(projectPath, config.input);
 const typesPath = path.join(projectPath, config.outputs.types);
 const utilsPath = path.join(projectPath, config.outputs.utils);
+const useOptionTypes = config.useOptionTypes;
 
 // tslint:disable-next-line:no-var-requires
 const objects = require(inputPath);
@@ -65,10 +66,9 @@ const addDiscoveredType = (type: IDiscoverableType) => {
 };
 
 const usableNotes = ({ _notes }: any): boolean => !!(_notes || []).find((n: any) => typeCheck.test(n));
-
+const isRequiredSchema = (schema: any) => (get(schema, "_flags.presence", "optional") as string === "required");
 const getUnion = (node: any): any[] => Array.from(get(node, "_valids._set", []));
-const propName = ({ key, schema }: any): string =>
-  (get(schema, "_flags.presence", "optional") as string === "required") ? key : `${key}?`;
+const propName = ({ key, schema }: any): string => (isRequiredSchema(schema) || useOptionTypes) ? key : `${key}?`;
 
 const joiToTypescript = (type: string) => {
   switch (type) {
@@ -105,6 +105,8 @@ const unwrapNotes = (type: string, notes: string[]): string => {
 const alternativesCheck = (schema: any): boolean => schema._type === "alternatives";
 const uuidCheck = (schema: any): boolean => !!get(schema, "_tests", []).find((t: any) => get(t, "name") === "guid");
 
+const optionTypeWrapper = (type: string) => `Option<${type}>`;
+
 const deriveType = (schema: any) => {
   if (schema._type === "array") { return unwrapArray(schema); }
   if (usableNotes(schema)) { return unwrapNotes(schema._type, schema._notes); }
@@ -139,7 +141,10 @@ const resolveTypeDefinition = (node: any): string => {
 
 const writeInterfaceType = (typeName: string, { _inner: { children }}: any): string =>
 `export interface ${typeName} {
-${children.map((child: any) => `  ${propName(child)}: ${deriveType(child.schema)};`).join("\n")}
+${children.map((child: any) => {
+  const wrap = (!isRequiredSchema(child.schema) && useOptionTypes) ? optionTypeWrapper : identity;
+  return `  ${propName(child)}: ${wrap(deriveType(child.schema))};`;
+}).join("\n")}
 }`;
 
 const writeTypeAlias = (typeName: string, type: string): string =>
@@ -180,6 +185,10 @@ const runTypeGenerator = () => {
   discoveredTypes
     .filter(t => !t.skip)
     .forEach(type => schemaOutput.unshift(writeTypeAlias(type.name, type.type)));
+
+  if (useOptionTypes) {
+    schemaOutput.unshift("import { Option } from \"fp-ts/lib/Option\";");
+  }
 
   const coerceOutput: string[] = Object.keys(schemaTypes).map(type =>
     typeTemplate(type, factoryTypes.some(n => n === type)));

--- a/src/coercionTemplate.ts
+++ b/src/coercionTemplate.ts
@@ -2,8 +2,8 @@
 import { compact } from "lodash";
 
 const imports = (optionTypes: boolean, schemasPath: string, typesPath: string) =>
-`${optionTypes ? "import * as option from \"fp-ts/lib/Option\";" : ""}
-import * as joi from "joi";
+`import * as freeze from "deep-freeze-strict";
+${optionTypes ? "import * as option from \"fp-ts/lib/Option\";\n" : ""}import * as joi from "joi";
 ${optionTypes ? "import { get } from \"lodash\";" : ""}
 import * as s from "${schemasPath}";
 import * as t from "${typesPath}";`;
@@ -65,12 +65,14 @@ const defaultOptions: joi.ValidationOptions = {
 export function coerceValue<T>(schema: joi.Schema) {
   ${optionTypes ? "const withOptionalTypes = convertOptionalFieldsToOptionTypes<T>(schema);\n  " : ""}return (object: any, options?: any): T => {
     const resolvedOptions = Object.assign({}, defaultOptions, options);
-    let coerced: T;
+    let coerced: any;
+
     joi.validate(object, schema, resolvedOptions, (err, result) => {
       if (err) { throw err; }
       coerced = result;
     });
-    return ${optionTypes ? "withOptionalTypes(coerced)" : "coerced"};
+
+    return freeze(${optionTypes ? "withOptionalTypes(coerced)" : "coerced"}) as T;
   };
 }
 

--- a/src/coercionTemplate.ts
+++ b/src/coercionTemplate.ts
@@ -1,12 +1,59 @@
-
+// tslint:disable:max-line-length
 import { compact } from "lodash";
 
-export const baseTemplate = (schemasPath: string, typesPath: string) =>
-`// tslint:disable:ordered-imports max-line-length
+const imports = (optionTypes: boolean, schemasPath: string, typesPath: string) =>
+`${optionTypes ? "import * as option from \"fp-ts/lib/Option\";" : ""}
 import * as joi from "joi";
-
+${optionTypes ? "import { get } from \"lodash\";" : ""}
 import * as s from "${schemasPath}";
-import * as t from "${typesPath}";
+import * as t from "${typesPath}";`;
+
+const optionTypeFunctions = () => `const isValueless = (obj: any) => (obj === undefined) || (obj === null);
+
+const wrapInOption = (val: any) => {
+  if (isValueless(val)) {
+    return option.none;
+  }
+
+  if (option.isNone(val) || option.isSome(val)) {
+    return val;
+  }
+
+  return option.some(val);
+};
+
+const wrapOptionalField = (schema: joi.Schema, obj: any): any => {
+  if (isValueless(obj)) {
+    return obj;
+  }
+
+  const fields = (schema as any)._inner.children as any[];
+
+  return fields.reduce((prev, field) => {
+    const value = prev[field.key];
+    const presence = field.schema._flags.presence;
+    const required = presence === "required";
+    const nested = (get(field, "schema._inner.children", []) || []).length > 0;
+
+    const recursedValue = nested
+      ? wrapOptionalField(field.schema, value)
+      : value;
+
+    const maybeValue = required
+      ? recursedValue
+      : wrapInOption(recursedValue);
+
+    return { ...prev, [field.key]: maybeValue };
+  }, obj);
+};
+
+export function convertOptionalFieldsToOptionTypes<T>(schema: joi.Schema) {
+  return (obj: any): T => wrapOptionalField(schema, obj);
+}`;
+
+export const baseTemplate = (optionTypes: boolean, schemasPath: string, typesPath: string) =>
+`// tslint:disable:ordered-imports max-line-length
+${imports(optionTypes, schemasPath, typesPath)}
 
 const defaultOptions: joi.ValidationOptions = {
   allowUnknown: true,
@@ -16,21 +63,23 @@ const defaultOptions: joi.ValidationOptions = {
 };
 
 export function coerceValue<T>(schema: joi.Schema) {
-  return (object: any, options?: any): T => {
+  ${optionTypes ? "const withOptionalTypes = convertOptionalFieldsToOptionTypes<T>(schema);\n  " : ""}return (object: any, options?: any): T => {
     const resolvedOptions = Object.assign({}, defaultOptions, options);
     let coerced: T;
     joi.validate(object, schema, resolvedOptions, (err, result) => {
       if (err) { throw err; }
       coerced = result;
     });
-    return coerced;
+    return ${optionTypes ? "withOptionalTypes(coerced)" : "coerced"};
   };
 }
 
 export function coerceFactory<T>(factory: Factory.IFactory, schema: joi.Schema) {
   return (attrs?: any, options?: any): T =>
     coerceValue<T>(schema)(factory.build(attrs, options));
-}`;
+}
+
+${optionTypes ? optionTypeFunctions() : ""}`;
 
 const coerceFactory = (name: string) =>
   `  build: coerceFactory<t.${name}>(s.${name}Factory, s.${name}Schema),`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,10 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+deep-freeze-strict@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze-strict/-/deep-freeze-strict-1.1.1.tgz#77d0583ca24a69be4bbd9ac2fae415d55523e5b0"
+
 diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"


### PR DESCRIPTION
The types produced by `joi-ts-generator` are great, except they suffer from a common ailment: `null`. Every time you want to work with a nullable field, you have to select from the usual anti-null weapons: `if`, `||`, `option.fromNullable`, etc. This is boilerplate, and should be automated away. 

This PR scratches my "no nullable fields" itch, instead having `Option<T>` with `None` where data was not provided. These `Option` types then compose nicely, simplifying app code.

I have added `useOptionTypes` config option, alongside the existing path options. If `false` or unset, the current behaviour persists. If `true`, your generated types have no nullable fields, instead their types are wrapped with `Option`. The `coerce` function is also modified to recurse through the provided schema, comparing wrapping properties when the schema says it is not `required`.

In writing this feature, I definitely felt the repo as a whole had crossed the "needs a nice-up" threshold. 🤙 