### PR TITLE
Quote interface field names when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.4",
     "read-pkg-up": "^2.0.0",
     "rosie": "^1.6.0",
-    "unquoted-property-validator": "^1.0.0"
+    "unquoted-property-validator": "^1.0.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "fp-ts": "^0.4.5",
     "lodash": "^4.17.4",
     "read-pkg-up": "^2.0.0",
-    "rosie": "^1.6.0"
+    "rosie": "^1.6.0",
+    "unquoted-property-validator": "^1.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/@types/unquoted-property-validator.d.ts
+++ b/src/@types/unquoted-property-validator.d.ts
@@ -1,9 +1,0 @@
-declare module "unquoted-property-validator" {
-    function unquotedValidator(propertyName: string): {
-        needsQuotes: boolean,
-        needsBrackets: boolean,
-        es3Warning: boolean,
-        quotedValue: string,
-    };
-    export = unquotedValidator;
-}

--- a/src/@types/unquoted-property-validator.d.ts
+++ b/src/@types/unquoted-property-validator.d.ts
@@ -1,0 +1,9 @@
+declare module "unquoted-property-validator" {
+    function unquotedValidator(propertyName: string): {
+        needsQuotes: boolean,
+        needsBrackets: boolean,
+        es3Warning: boolean,
+        quotedValue: string,
+    };
+    export = unquotedValidator;
+}

--- a/src/writers/types.ts
+++ b/src/writers/types.ts
@@ -1,5 +1,6 @@
 import { groupBy, keys, toPairs } from "lodash";
 import * as path from "path";
+import unquotedValidator = require("unquoted-property-validator");
 import { Config } from "../config";
 import {
   hasOptionalField,
@@ -57,13 +58,16 @@ const fieldToString = (field: Field): string => {
   return field.type.name;
 };
 
+const encodeFieldKey = (key: string): string => unquotedValidator(key).quotedValue;
+
 const interfaceToString = (config: Config, type: VisitedType): string => {
   const iface = type.class as InterfaceType;
   const fields = iface.fields
     .map(field => {
+      const encodedKey = encodeFieldKey(field.key);
       const key = config.nullableMode === "option" || field.required
-        ? field.key
-        : `${field.key}?`;
+        ? encodedKey
+        : `${encodedKey}?`;
       const fieldType = fieldToString(field);
       const maybeFieldType = config.nullableMode === "option" && !field.required
         ? `Option<${fieldType}>`
@@ -97,7 +101,7 @@ ${alternatives};
 `;
 };
 
-const typeToString = (config: Config) => (type: VisitedType): string => {
+export const typeToString = (config: Config) => (type: VisitedType): string => {
   if (isArray(type.class)) {
     return arrayToString(type);
   }

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,56 @@
+import { Config } from "../src/config";
+import { VisitedType } from "../src/schemaVisitor/types";
+import { typeToString } from "../src/writers/types";
+
+const config: Config = {
+    nullableMode: "nullable",
+    paths: {
+        input: "dummy",
+        library: "dummy",
+        project: "dummy",
+        types: "dummy",
+        utils: "dummy",
+    },
+    typeImports: {},
+};
+
+describe("an interface member with special characters", () => {
+  test("it is quoted correctly", () => {
+    const inputType: VisitedType = {
+      class: {
+        fields: [
+            {
+                key: "foo",
+                required: true,
+                type: {
+                    class: {
+                        kind: "basic",
+                        type: "string",
+                    },
+                    name: "string",
+                },
+            },
+            {
+                key: "foo-dashed",
+                required: true,
+                type: {
+                    class: {
+                        kind: "basic",
+                        type: "string",
+                    },
+                    name: "string",
+                },
+            },
+        ],
+        kind: "interface",
+      },
+      name: "Test",
+    };
+    const outputDecl = typeToString(config)(inputType);
+    expect(outputDecl).toBe("" +
+        "export interface Test {\n" +
+        "  foo: string;\n" +
+        "  'foo-dashed': string;\n" +
+        "}\n");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,9 +2235,9 @@ universalify@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
-unquoted-property-validator@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unquoted-property-validator/-/unquoted-property-validator-1.0.0.tgz#e63618c9cadd25ce82f0e33db951ffdfa694fc3a"
+unquoted-property-validator@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unquoted-property-validator/-/unquoted-property-validator-1.0.2.tgz#edd75c6a4481fbbc094b3b4c35035863df6bbcef"
 
 user-home@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,6 +2235,10 @@ universalify@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
+unquoted-property-validator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unquoted-property-validator/-/unquoted-property-validator-1.0.0.tgz#e63618c9cadd25ce82f0e33db951ffdfa694fc3a"
+
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"


### PR DESCRIPTION
I was validating http headers using joi and tried to create a type for it
```ts
const acceptLanguage = Joi.string().example('sv').regex(/^..$/)
  .description('The language code to use e.g. en, sv, fi etc');
export const MyRequestHeadersSchema = Joi.object({
  'accept-language': acceptLanguage.required()
});
```
but this resulted in
```ts
export interface CreateOrderRequestHeaders {
  accept-language: string;
}
```
.. when the expected result would be:
```ts
export interface CreateOrderRequestHeaders {
  'accept-language': string;
}
```
So this PR attempts to add proper quoting of field names, when needed.